### PR TITLE
Chore: update GitHub Actions workflow to use latest versions of dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,19 +11,19 @@ permissions: read-all
 jobs:
   test:
     name: Run Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: 8.0.0
 
       - name: Install Node.js 18 and setup dependency caching
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
           cache: 'pnpm'


### PR DESCRIPTION

This pull request updates the GitHub Actions workflow configuration to use the latest versions of runners and actions, ensuring better security, compatibility, and access to new features.

CI/CD maintenance:

* Updated the runner for the test job from `ubuntu-20.04` to `ubuntu-latest` in `.github/workflows/test.yml` for improved compatibility and access to the latest environment.
* Upgraded action versions in `.github/workflows/test.yml`:
  * `actions/checkout` from v3 to v4
  * `pnpm/action-setup` from v2 to v4
  * `actions/setup-node` from v3 to v4
  These updates provide bug fixes, security improvements, and new features.